### PR TITLE
Add Chaos demo for zone down

### DIFF
--- a/iac/createResources.bicep
+++ b/iac/createResources.bicep
@@ -1846,7 +1846,7 @@ resource chaosvmssexperiment 'Microsoft.Chaos/experiments@2022-10-01-preview' = 
             name: 'branch1'
             actions: [
               {
-                name: 'urn:csci:microsoft:azureVirtualMachineScaleSet:shutdown/2.0'
+                name: 'urn:csci:microsoft:virtualMachineScaleSet:shutdown/2.0'
                 type: 'continuous'
                 selectorId: chaosVmssSelectorId
                 duration: 'PT5M'


### PR DESCRIPTION
Fixes #191
- BLOCKED https://github.com/Azure/AKS/issues/3293
- We'll need to manually delete the existing aks cluster to re-create using 3 availability zones (I don't have permissions in current sub)
- TODO: add to walkthrough doc