### PR TITLE
devops: trigger on main pushes CI checks as well

### DIFF
--- a/.github/workflows/contoso-traders-cloud-testing.yml
+++ b/.github/workflows/contoso-traders-cloud-testing.yml
@@ -2,6 +2,8 @@ name: contoso-traders-cloud-testing
 
 on:
   workflow_dispatch:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
     paths-ignore: ["docs/**", "demo-scripts/**"]


### PR DESCRIPTION
GitHub Status Checks are red because I have two PRs and they will cancel each-other since they are in the same concurrency group.