### PR TITLE
skipping file upload test for lab

### DIFF
--- a/src/ContosoTraders.Ui.Website/tests/fileupload.spec.ts
+++ b/src/ContosoTraders.Ui.Website/tests/fileupload.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 const imgPath = path.join(__dirname, '../src/assets/images/original/Contoso_Assets/Grid_Products_Collection/product_image.png');
 
-test.describe('File Upload', () => {
+test.describe.skip('File Upload', () => {
   test('should be able to upload a file', async ({ page }) => {
     await page.goto("/");
     await page.getByRole('button', { name: 'iconimage' }).click();


### PR DESCRIPTION
# Change Description

Disabled file upload test for Skillable lab, where Cognitive Services infra was removed.

Please check all options that are relevant.

- [x] I have made all necessary updates to the documentation.
- [x] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
