### PR TITLE
devops: hide k8s-lint Node.js deprecation warning

### DIFF
--- a/.github/workflows/contoso-traders-cloud-testing.yml
+++ b/.github/workflows/contoso-traders-cloud-testing.yml
@@ -276,7 +276,7 @@ jobs:
         env:
           SUFFIX: ${{ vars.SUFFIX }}
       - name: lint deployment manifest
-        uses: azure/k8s-lint@v2.0
+        uses: azure/k8s-lint@4a3fddd6e0906514b426af21958f431722e8c8bf
         with:
           manifests: ./src/ContosoTraders.Api.Products/Manifests/Deployment.yaml
       - name: apply deployment manifest


### PR DESCRIPTION
https://github.com/Azure/k8s-lint/issues/45 isn't released yet, see: https://github.com/Azure/k8s-lint/compare/v2.0...main

The actual fix was https://github.com/Azure/k8s-lint/pull/30 so we are pinning now to the exact commit which includes this fix.