### PR TITLE
[skip ci] Remove PR trigger (fixes #245)

### DIFF
--- a/.github/workflows/contoso-traders-cloud-testing.yml
+++ b/.github/workflows/contoso-traders-cloud-testing.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
     paths-ignore: ["docs/**", "demo-scripts/**"]
 
 env:


### PR DESCRIPTION
# Change Description

Removing the PR trigger from the prod pipeline (GitHub workflow), to prevent PR builds from getting pushed to prod.

The PR trigger will however remain on the AZD pipeline which pushes to staging.

## Linked GitHub Issue

Fixes # 245

## Checklist

Please check all options that are relevant.

- [x] I have made all necessary updates to the documentation.
- [x] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
