### PR TITLE
Fix broken link in docs

### DIFF
--- a/demo-scripts/dev-workflow/walkthrough.md
+++ b/demo-scripts/dev-workflow/walkthrough.md
@@ -12,7 +12,7 @@ The key takeaways from this demo are:
   
 ## Before you Begin
 
-You must have Contoso Traders deployed in your environment and setup with GitHub Actions.  Please refer to the deployment instructions [here](../demo-scripts/app-deployment-guide.md)
+You must have Contoso Traders deployed in your environment and setup with GitHub Actions.  Please refer to the deployment instructions [here](../../docs/deployment-instructions.md)
 
 ## Walkthrough – GitHub Actions for CI/CD
 


### PR DESCRIPTION
Fix broken link in dev-workflow walkthrough

# Change Description

Fixed broken link in dev-workflow/walkthrough.md

## Linked GitHub Issue

https://github.com/microsoft/contosotraders-cloudtesting/issues/252

## Checklist

Please check all options that are relevant.

- [x] I have made all necessary updates to the documentation.
- [ ] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
