### PR TITLE
Use .env.playwright.local file to manage local environment variables

### DIFF
--- a/demo-scripts/testing-with-playwright/walkthrough.md
+++ b/demo-scripts/testing-with-playwright/walkthrough.md
@@ -27,7 +27,7 @@ The Playwright docs have more details here: [Using the Playwright VSCode Extensi
 
     1. Drill into the latest run by clicking on the `playwright-tests-ui` job, then clicking on the step `Set env variables for testing endpoints`.
     ![image](media/actions1.png)
-    1. This project uses a `.env` file to easily manage these variables. Open `src\ContosoTraders.Ui.Website\.env` and set the following environment variables using the values from the logs above (these will be unique to your environment). NOTE: Do NOT check in these changes to source control!:
+    1. This project uses a `.env.playwright.local` file to easily manage these variables. Open `src\ContosoTraders.Ui.Website\.env.playwright.local` and set the following environment variables using the values from the logs above (these will be unique to your environment). NOTE: Do NOT check in these changes to source control!:
 
     ```bash
     REACT_APP_APIURLSHOPPINGCART = ''

--- a/src/ContosoTraders.Ui.Website/.gitignore
+++ b/src/ContosoTraders.Ui.Website/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env.playwright.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/ContosoTraders.Ui.Website/playwright.config.ts
+++ b/src/ContosoTraders.Ui.Website/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-require('dotenv').config()
+require('dotenv').config({ path: '.env.playwright.local' })
 
 export default defineConfig({
   testDir: './tests',


### PR DESCRIPTION
# Change Description

Use .env.playwright.local file to manage local environment variables, instead of .env which React app relies on. This will allow us to gitignore the file and store AAD creds and testing endpoints.

## Checklist

Please check all options that are relevant.

- [x] I have made all necessary updates to the documentation.
- [x] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
