### PR TITLE
[DRAFT][DO NOT MERGE] Cost budgets & alerts

### DIFF
--- a/docs/deployment-instructions.md
+++ b/docs/deployment-instructions.md
@@ -159,5 +159,5 @@ A quick note on costs considerations when you deploy the application to your Azu
 >
 > The above costs are based on the default configuration of the demo. You can modify the configuration to reduce the costs. For example, you can reduce the number of instances in the container app, reduce the number of virtual users in the load test, etc.
 >
-> Our deployment script automatically sets up cost alerts at the subscription level. A budget of $100 is set. Email alerts are triggered when 50%, 75%, and 90% thresholds are exceeded and emails are sent subscription owners, contributors.
+> Our deployment script automatically sets up cost alerts at the subscription level. A budget of $100 is set. Email alerts are sent to the subscription owners, contributors when 50%, 75%, and 90% thresholds are exceeded.
 >

--- a/docs/deployment-instructions.md
+++ b/docs/deployment-instructions.md
@@ -159,3 +159,5 @@ A quick note on costs considerations when you deploy the application to your Azu
 >
 > The above costs are based on the default configuration of the demo. You can modify the configuration to reduce the costs. For example, you can reduce the number of instances in the container app, reduce the number of virtual users in the load test, etc.
 >
+> Our deployment script automatically sets up cost alerts at the subscription level. A budget of $100 is set. Email alerts are triggered when 50%, 75%, and 90% thresholds are exceeded and emails are sent subscription owners, contributors.
+>

--- a/iac/createResourceGroup.bicep
+++ b/iac/createResourceGroup.bicep
@@ -28,8 +28,20 @@ param suffix string
 ])
 param rgLocation string
 
+// The utcNow() function can only be used in the default value of a parameter.
+// Details: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-date#utcnow
+param currentDateTimeUtc string = utcNow('yyyy-MM-dd')
+
 // variables
 ////////////////////////////////////////////////////////////////////////////////
+
+var costBudgetName = 'monthly-cost-budget-${suffix}'
+
+// roles alerted when cost budget is exceeded
+var costBudgetContactRoles = [
+  'Owner'
+  'Contributor'
+]
 
 // tags
 var rgTags = {
@@ -44,6 +56,50 @@ resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   name: '${rgName}${suffix}'
   location: rgLocation
   tags: rgTags
+}
+
+//
+// consumption: budgets and alerts
+//
+
+// budget: monthly under 100$
+resource budgetmonthlyunder100 'Microsoft.Consumption/budgets@2021-10-01' = {
+  name: costBudgetName
+  properties: {
+    timePeriod: {
+      // must be in YYYY-MM-DD format, and must be the first day of the current time grain (i.e month)
+      startDate: '${substring(currentDateTimeUtc, 0, 7)}-01'
+    }
+    timeGrain: 'Monthly'
+    amount: 100
+    category: 'Cost'
+    notifications: {
+      NotificationFor50PercentExceededBudget: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 50
+        contactRoles: costBudgetContactRoles
+        contactEmails: []
+        thresholdType: 'Actual'
+      }
+      NotificationFor75PercentExceededBudget: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 75
+        contactRoles: costBudgetContactRoles
+        contactEmails: []
+        thresholdType: 'Actual'
+      }
+      NotificationFor90PercentExceededBudget: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 90
+        contactRoles: costBudgetContactRoles
+        contactEmails: []
+        thresholdType: 'Actual'
+      }
+    }
+  }
 }
 
 // outputs


### PR DESCRIPTION
# Change Description

1. Setting a cost budget cap of $100 at the subscription level. 
2. Email alerts will be triggered when 50%, 75%, and 90% thresholds are exceeded.
3. Email alerts will be routed to folks in subscription `owner`, and `contributor` roles.

![image](https://github.com/microsoft/contosotraders-cloudtesting/assets/2327905/8ec4ebe8-d041-4d73-8336-f5e312f2c553)

![image](https://github.com/microsoft/contosotraders-cloudtesting/assets/2327905/43668cf4-bb8b-4ceb-a9c9-4623f88bd10b)

## Linked GitHub Issue

Fixes #110 

## Checklist

Please check all options that are relevant.

- [x] I have made all necessary updates to the documentation.
- [x] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
