### PR TITLE
Pipeline retries fix

### DIFF
--- a/.azurepipelines/contoso-traders-cloud-testing.yml
+++ b/.azurepipelines/contoso-traders-cloud-testing.yml
@@ -758,9 +758,10 @@ stages:
               mergeTestResults: true
               failTaskOnFailedTests: true
               testRunTitle: Playwright Tests
-          - task: PublishPipelineArtifact@1
+          - task: PublishBuildArtifacts@1
             displayName: upload playwright report
-            condition: always()
+            condition: failed()
             inputs:
-              artifact: playwright-report
-              targetPath: src/ContosoTraders.Ui.Website/playwright-report
+              PathtoPublish: 'src/ContosoTraders.Ui.Website/playwright-report'
+              ArtifactName: 'playwright-report'
+              publishLocation: 'Container'              

--- a/.github/workflows/contoso-traders-cloud-testing.yml
+++ b/.github/workflows/contoso-traders-cloud-testing.yml
@@ -652,10 +652,12 @@ jobs:
       - name: install dependencies
         run: npm ci
       - name: run playwright tests
+        id: test
         run: HOME=/root npx playwright test
       - name: upload playwright report
         uses: actions/upload-artifact@v3
-        if: always()
+        # only upload report if tests failed
+        if: steps.test.outcome != 'success'
         with:
           name: playwright-report
           path: src/ContosoTraders.Ui.Website/playwright-report/


### PR DESCRIPTION
# Change Description

**Azure Pipelines:** task PublishPipelineArftifacts fails to upload Playwright report upon retry. We can either use System.JobAttempt var in the artifact name, or use PublishBuildArtifacts task that fixes this. I've chosen the latter for now.

**GitHub Actions:** only upload Playwright report if tests fail. Uploading every time is unnecessary.

## Checklist

Please check all options that are relevant.

- [ ] I have made all necessary updates to the documentation.
- [ ] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [ ] This is not a breaking change.
