### PR TITLE
Hotfix 266

### DIFF
--- a/iac/createResources.bicep
+++ b/iac/createResources.bicep
@@ -264,7 +264,7 @@ resource kv 'Microsoft.KeyVault/vaults@2022-07-01' = {
     tags: resourceTags
     properties: {
       contentType: 'endpoint url (fqdn) of the (internal) carts api'
-      value: cartsinternalapiaca.properties.configuration.ingress.fqdn
+      value: deployPrivateEndpoints ? cartsinternalapiaca.properties.configuration.ingress.fqdn : ''
     }
   }
 
@@ -1490,10 +1490,10 @@ resource jumpboxvmschedule 'Microsoft.DevTestLab/schedules@2018-09-15' = {
 module privateDnsZone './createPrivateDnsZone.bicep' = if (deployPrivateEndpoints) {
   name: 'createPrivateDnsZone'
   params: {
-    privateDnsZoneName: join(skip(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.')
+    privateDnsZoneName: deployPrivateEndpoints ? join(skip(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.') : ''
     privateDnsZoneVnetId: vnet.id
     privateDnsZoneVnetLinkName: privateDnsZoneVnetLinkName
-    privateDnsZoneARecordName: join(take(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.')
+    privateDnsZoneARecordName: deployPrivateEndpoints ? join(take(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.') : ''
     privateDnsZoneARecordIp: cartsinternalapiacaenv.properties.staticIp
     resourceTags: resourceTags
   }

--- a/iac/createResources.bicep
+++ b/iac/createResources.bicep
@@ -1494,7 +1494,7 @@ module privateDnsZone './createPrivateDnsZone.bicep' = if (deployPrivateEndpoint
     privateDnsZoneVnetId: vnet.id
     privateDnsZoneVnetLinkName: privateDnsZoneVnetLinkName
     privateDnsZoneARecordName: deployPrivateEndpoints ? join(take(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.') : ''
-    privateDnsZoneARecordIp: cartsinternalapiacaenv.properties.staticIp
+    privateDnsZoneARecordIp: deployPrivateEndpoints ? cartsinternalapiacaenv.properties.staticIp : ''
     resourceTags: resourceTags
   }
 }


### PR DESCRIPTION
# Change Description

Fixes `resource not found` error caused by implicit dependency properties when private endpoint resources aren't created.

Please check all options that are relevant.

- [x] I have made all necessary updates to the documentation.
- [x] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
