### PR TITLE
conditional deployment of Jumpbox VM

### DIFF
--- a/.azurepipelines/contoso-traders-cloud-testing.yml
+++ b/.azurepipelines/contoso-traders-cloud-testing.yml
@@ -201,7 +201,7 @@ stages:
               resourceGroupName: "$(RESOURCE_GROUP_NAME)$(SUFFIX)"
               csmFile: ./iac/createResources.bicep
               csmParametersFile: ./iac/createResources.parameters.json
-              overrideParameters: -suffix $(SUFFIX) -sqlPassword $(SQLPASSWORD)
+              overrideParameters: -suffix $(SUFFIX) -sqlPassword $(SQLPASSWORD) -deployPrivateEndpoints $(DEPLOYPRIVATEENDPOINTS)
 
           # Add the logged-in service principal to the key vault access policy
           - task: AzureCLI@1
@@ -274,7 +274,7 @@ stages:
                 az containerapp update -n $(CARTS_ACA_NAME)$(SUFFIX) -g $(RESOURCE_GROUP_NAME)$(SUFFIX) --image $(ACR_NAME)$(SUFFIX).azurecr.io/$(CARTS_ACR_REPOSITORY_NAME):$(Build.SourceVersion)
           - task: AzureCLI@1
             displayName: deploy to aca (internal)
-            condition: ne(variables['DEPLOYPRIVATEENDPOINTS'], '')
+            condition: eq(variables['DEPLOYPRIVATEENDPOINTS'], 'true')
             inputs:
               azureSubscription: SERVICEPRINCIPAL
               scriptLocation: inlineScript
@@ -613,7 +613,7 @@ stages:
                 ]
 
       - job: load_tests_carts_internal_api
-        condition: ne(variables['DEPLOYPRIVATEENDPOINTS'], '')
+        condition: eq(variables['DEPLOYPRIVATEENDPOINTS'], 'true')
         dependsOn: [provision, playwright_tests_ui]
         steps:
           - task: AzureCLI@1

--- a/.github/workflows/contoso-traders-cloud-testing.yml
+++ b/.github/workflows/contoso-traders-cloud-testing.yml
@@ -219,7 +219,7 @@ jobs:
             az config set extension.use_dynamic_install=yes_without_prompt
             az containerapp update -n ${{ env.CARTS_ACA_NAME }}${{ vars.SUFFIX }} -g ${{ env.RESOURCE_GROUP_NAME }}${{ vars.SUFFIX }} --image ${{ env.ACR_NAME }}${{ vars.SUFFIX }}.azurecr.io/${{ env.CARTS_ACR_REPOSITORY_NAME }}:${{ github.sha }}
       - name: deploy to aca (internal)
-        if: ${{ vars.DEPLOYPRIVATEENDPOINTS }}
+        if: ${{ vars.DEPLOYPRIVATEENDPOINTS == 'true' }}
         uses: azure/CLI@v1
         with:
           inlineScript: |
@@ -507,7 +507,7 @@ jobs:
             ]
 
   load-tests-carts-internal-api:
-    if: ${{ vars.DEPLOYPRIVATEENDPOINTS }}
+    if: ${{ vars.DEPLOYPRIVATEENDPOINTS == 'true' }}
     needs: [provision, playwright-tests-ui]
     runs-on: ubuntu-22.04
     concurrency:

--- a/iac/createResources.bicep
+++ b/iac/createResources.bicep
@@ -264,7 +264,7 @@ resource kv 'Microsoft.KeyVault/vaults@2022-07-01' = {
     tags: resourceTags
     properties: {
       contentType: 'endpoint url (fqdn) of the (internal) carts api'
-      value: deployPrivateEndpoints ? cartsinternalapiaca.properties.configuration.ingress.fqdn : ''
+      value: cartsinternalapiaca.properties.configuration.ingress.fqdn
     }
   }
 
@@ -309,7 +309,7 @@ resource kv 'Microsoft.KeyVault/vaults@2022-07-01' = {
   }
 
   // secret
-  resource kv_secretVnetAcaSubnetId 'secrets' = {
+  resource kv_secretVnetAcaSubnetId 'secrets' = if (deployPrivateEndpoints) {
     name: kvSecretNameVnetAcaSubnetId
     tags: resourceTags
     properties: {
@@ -1318,7 +1318,7 @@ resource aks_roleassignmentforchaosexp 'Microsoft.Authorization/roleAssignments@
 // virtual network
 //
 
-resource vnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
+resource vnet 'Microsoft.Network/virtualNetworks@2022-07-01' = if (deployPrivateEndpoints) {
   name: vnetName
   location: resourceLocation
   tags: resourceTags
@@ -1356,7 +1356,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
 // 
 
 // public ip address
-resource jumpboxpublicip 'Microsoft.Network/publicIPAddresses@2022-07-01' = {
+resource jumpboxpublicip 'Microsoft.Network/publicIPAddresses@2022-07-01' = if (deployPrivateEndpoints) {
   name: jumpboxPublicIpName
   location: resourceLocation
   tags: resourceTags
@@ -1371,7 +1371,7 @@ resource jumpboxpublicip 'Microsoft.Network/publicIPAddresses@2022-07-01' = {
 }
 
 // network security group
-resource jumpboxnsg 'Microsoft.Network/networkSecurityGroups@2022-07-01' = {
+resource jumpboxnsg 'Microsoft.Network/networkSecurityGroups@2022-07-01' = if (deployPrivateEndpoints) {
   name: jumpboxNsgName
   location: resourceLocation
   tags: resourceTags
@@ -1395,7 +1395,7 @@ resource jumpboxnsg 'Microsoft.Network/networkSecurityGroups@2022-07-01' = {
 }
 
 // network interface controller
-resource jumpboxnic 'Microsoft.Network/networkInterfaces@2022-07-01' = {
+resource jumpboxnic 'Microsoft.Network/networkInterfaces@2022-07-01' = if (deployPrivateEndpoints) {
   name: jumpboxNicName
   location: resourceLocation
   tags: resourceTags
@@ -1423,7 +1423,7 @@ resource jumpboxnic 'Microsoft.Network/networkInterfaces@2022-07-01' = {
 }
 
 // virtual machine
-resource jumpboxvm 'Microsoft.Compute/virtualMachines@2022-08-01' = {
+resource jumpboxvm 'Microsoft.Compute/virtualMachines@2022-08-01' = if (deployPrivateEndpoints) {
   name: jumpboxVmName
   location: resourceLocation
   tags: resourceTags
@@ -1465,7 +1465,7 @@ resource jumpboxvm 'Microsoft.Compute/virtualMachines@2022-08-01' = {
 }
 
 // auto-shutdown schedule
-resource jumpboxvmschedule 'Microsoft.DevTestLab/schedules@2018-09-15' = {
+resource jumpboxvmschedule 'Microsoft.DevTestLab/schedules@2018-09-15' = if (deployPrivateEndpoints) {
   name: jumpboxVmShutdownSchduleName
   location: resourceLocation
   tags: resourceTags
@@ -1490,11 +1490,11 @@ resource jumpboxvmschedule 'Microsoft.DevTestLab/schedules@2018-09-15' = {
 module privateDnsZone './createPrivateDnsZone.bicep' = if (deployPrivateEndpoints) {
   name: 'createPrivateDnsZone'
   params: {
-    privateDnsZoneName: deployPrivateEndpoints ? join(skip(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.') : ''
+    privateDnsZoneName: join(skip(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.')
     privateDnsZoneVnetId: vnet.id
     privateDnsZoneVnetLinkName: privateDnsZoneVnetLinkName
-    privateDnsZoneARecordName: deployPrivateEndpoints ? join(take(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.') : ''
-    privateDnsZoneARecordIp: deployPrivateEndpoints ? cartsinternalapiacaenv.properties.staticIp : ''
+    privateDnsZoneARecordName: join(take(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.')
+    privateDnsZoneARecordIp: cartsinternalapiacaenv.properties.staticIp
     resourceTags: resourceTags
   }
 }


### PR DESCRIPTION
# Change Description

>Note: This is a part of a series of changes related to conditional deployment of private ACA endpoints.

1. The jumpbox VM (and associated networking components) are only required to access the private/internal version of the carts API. Hence these too can be conditionally deployed.

2. Created a variable `DEPLOYPRIVATEENDPOINTS` in the `contosotraders-cloudtesting-variable-group` AZD pipeline variable group. Essentially this is the AZD pipeline equivalent of the GitHub repository variable.
   
   ![image](https://github.com/microsoft/contosotraders-cloudtesting/assets/2327905/9ad27700-b2e1-47ec-80f7-20b4a95f036d)

3. In bicep templates, the conditional expression operator `? :` is only required when using `reference()` or `list*()` functions. Else can be removed. [Source](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/conditional-resource-deployment#runtime-functions)

## Linked GitHub Issue

N/A

## Checklist

Please check all options that are relevant.

- [ ] I have made all necessary updates to the documentation.
- [ ] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
