### PR TITLE
Minor fix: referencing a property of a conditional resource may produce a deployment error 

### DIFF
--- a/iac/createResources.bicep
+++ b/iac/createResources.bicep
@@ -264,7 +264,7 @@ resource kv 'Microsoft.KeyVault/vaults@2022-07-01' = {
     tags: resourceTags
     properties: {
       contentType: 'endpoint url (fqdn) of the (internal) carts api'
-      value: cartsinternalapiaca.properties.configuration.ingress.fqdn
+      value: deployPrivateEndpoints ? cartsinternalapiaca.properties.configuration.ingress.fqdn : ''
     }
   }
 
@@ -1490,11 +1490,11 @@ resource jumpboxvmschedule 'Microsoft.DevTestLab/schedules@2018-09-15' = if (dep
 module privateDnsZone './createPrivateDnsZone.bicep' = if (deployPrivateEndpoints) {
   name: 'createPrivateDnsZone'
   params: {
-    privateDnsZoneName: join(skip(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.')
+    privateDnsZoneName: deployPrivateEndpoints ? join(skip(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.') : ''
     privateDnsZoneVnetId: vnet.id
     privateDnsZoneVnetLinkName: privateDnsZoneVnetLinkName
-    privateDnsZoneARecordName: join(take(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.')
-    privateDnsZoneARecordIp: cartsinternalapiacaenv.properties.staticIp
+    privateDnsZoneARecordName: deployPrivateEndpoints ? join(take(split(cartsinternalapiaca.properties.configuration.ingress.fqdn, '.'), 2), '.') : ''
+    privateDnsZoneARecordIp: deployPrivateEndpoints ? cartsinternalapiacaenv.properties.staticIp : ''
     resourceTags: resourceTags
   }
 }


### PR DESCRIPTION
# Change Description

This is a follow-up fix to my previous PR. 

For implicit dependencies, referencing a property of a conditional resource is allowed but may produce a deployment error ([source](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/conditional-resource-deployment#define-condition-for-deployment)).

Hence need to use conditional expressions.

## Linked GitHub Issue

N/A

## Checklist

Please check all options that are relevant.

- [ ] I have made all necessary updates to the documentation.
- [ ] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
