### PR TITLE
Configured Public access for storage account to enable anounymous access for blob container

### DIFF
--- a/iac/createResources.bicep
+++ b/iac/createResources.bicep
@@ -720,7 +720,9 @@ resource productimagesstgacc 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     name: 'Standard_LRS'
   }
   kind: 'StorageV2'
-
+  properties: {
+    allowBlobPublicAccess: true
+  }
   // blob service
   resource productimagesstgacc_blobsvc 'blobServices' = {
     name: 'default'
@@ -757,7 +759,9 @@ resource uistgacc 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     name: 'Standard_LRS'
   }
   kind: 'StorageV2'
-
+  properties: {
+    allowBlobPublicAccess: true
+  }
   // blob service
   resource uistgacc_blobsvc 'blobServices' = {
     name: 'default'
@@ -905,6 +909,9 @@ resource imageclassifierstgacc 'Microsoft.Storage/storageAccounts@2022-09-01' = 
     name: 'Standard_LRS'
   }
   kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: true
+  }
 
   // blob service
   resource imageclassifierstgacc_blobsvc 'blobServices' = {


### PR DESCRIPTION
# Change Description

Configured Public access for storage account to enable anounymous access for blob container to prevent provisioning resources deployment issues. 

## Linked GitHub Issue

> Link to any related github issue number (e.g. #56).

Fixes # (issue)

## Checklist

Please check all options that are relevant.

- [x] I have made all necessary updates to the documentation.
- [x] I have made all necessary updates to the provisioning scripts (bicep templates, github workflows).
- [x] This is not a breaking change.
